### PR TITLE
#bugfix

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -848,6 +848,12 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      */
     private boolean shouldCloseClientConnection(HttpRequest req,
             HttpResponse res, HttpObject httpObject) {
+        // In case of manual proxy authentication, we need to close the request to let the browser resend a request with
+        // the authentication informations
+        if (res.getStatus().code() == 407 && proxyServer.isManualUpstreamProxyAuth()) {
+            LOG.debug("Closing client connection since response is 407", res);
+            return true;
+        }
         if (ProxyUtils.isChunked(res)) {
             // If the response is chunked, we want to return false unless it's
             // the last chunk. If it is the last chunk, then we want to pass


### PR DESCRIPTION
Close client connection in any cases when we receive 407 response
Incoherent reson phrase compared to the status code with a proxy forward ex. 401 : Proxy authentication required